### PR TITLE
Fix bug with package names that include a dash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-testing"
-version = "0.0.2b1"
+version = "0.0.2b2"
 description = "A library to standardize testing of GeneWeaver pacakges."
 authors = ["Alexander Berger <alexander.berger@jax.org>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-testing"
-version = "0.0.1b0"
+version = "0.0.2b0"
 description = "A library to standardize testing of GeneWeaver pacakges."
 authors = ["Alexander Berger <alexander.berger@jax.org>"]
 readme = "README.md"
@@ -23,6 +23,9 @@ pytest-cov = "^4.1.0"
 
 [tool.ruff]
 select = ['F', 'E', 'W', 'A', 'C90', 'N', 'B', 'ANN', 'D', 'I', 'ERA', 'PD', 'NPY', 'PT']
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["ANN001", "ANN201"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-testing"
-version = "0.0.2b0"
+version = "0.0.2b1"
 description = "A library to standardize testing of GeneWeaver pacakges."
 authors = ["Alexander Berger <alexander.berger@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/testing/fixtures/package.py
+++ b/src/geneweaver/testing/fixtures/package.py
@@ -13,6 +13,7 @@ __all__ = [
     "pyproject_toml_contents",
     "package_name_from_pyproject",
     "package_submodule_name",
+    "is_tool_package",
 ]
 
 
@@ -73,3 +74,9 @@ def package_submodule_name(package_name_from_pyproject: Optional[str]) -> Option
         if package_name_from_pyproject
         else None
     )
+
+
+@pytest.fixture(scope="session")
+def is_tool_package(project_root: Optional[str]) -> bool:
+    """Return True if the package is a tool package."""
+    return (project_root / "src" / "geneweaver" / "tools").is_dir()

--- a/src/geneweaver/testing/fixtures/package.py
+++ b/src/geneweaver/testing/fixtures/package.py
@@ -69,7 +69,7 @@ def package_name_from_pyproject(
 def package_submodule_name(package_name_from_pyproject: Optional[str]) -> Optional[str]:
     """Get the package name from the pyproject.toml file."""
     return (
-        package_name_from_pyproject.split("-")[-1]
+        "_".join(package_name_from_pyproject.split("-")[1:])
         if package_name_from_pyproject
         else None
     )

--- a/src/geneweaver/testing/package/can_import.py
+++ b/src/geneweaver/testing/package/can_import.py
@@ -17,15 +17,21 @@ ERROR_MESSAGE = (
 )
 
 
-def test_can_import_absolute(package_submodule_name: Optional[str]) -> None:
+def test_can_import_absolute(
+    package_submodule_name: Optional[str], is_tool_package: bool
+) -> None:
     """Test that we can import the package from the top level namespace."""
-    module = importlib.import_module(f"geneweaver.{package_submodule_name}")
+    root_module = "geneweaver.tools" if is_tool_package else "geneweaver"
+    module = importlib.import_module(f"{root_module}.{package_submodule_name}")
     assert module is not None, ERROR_MESSAGE
 
 
-def test_can_import_relative(package_submodule_name: Optional[str]) -> None:
+def test_can_import_relative(
+    package_submodule_name: Optional[str], is_tool_package: bool
+) -> None:
     """Test that we can import the package relative to the geneweaver namespace."""
-    module = importlib.import_module(f".{package_submodule_name}", "geneweaver")
+    root_module = "geneweaver.tools" if is_tool_package else "geneweaver"
+    module = importlib.import_module(f".{package_submodule_name}", root_module)
     assert module is not None, ERROR_MESSAGE
 
 
@@ -40,10 +46,13 @@ def test_can_import_geneweaver() -> None:
 
 
 def test_submodule_available_from_namespace_package(
-    package_submodule_name: Optional[str],
+    package_submodule_name: Optional[str], is_tool_package: bool
 ) -> None:
     """Test that the package is available from the geneweaver namespace."""
     import geneweaver
+
+    if is_tool_package:
+        package_submodule_name = f"tools.{package_submodule_name}"
 
     assert hasattr(geneweaver, package_submodule_name), ERROR_MESSAGE
     assert getattr(geneweaver, package_submodule_name) is not None, ERROR_MESSAGE

--- a/src/geneweaver/testing/package/can_import.py
+++ b/src/geneweaver/testing/package/can_import.py
@@ -49,10 +49,15 @@ def test_submodule_available_from_namespace_package(
     package_submodule_name: Optional[str], is_tool_package: bool
 ) -> None:
     """Test that the package is available from the geneweaver namespace."""
-    import geneweaver
-
     if is_tool_package:
-        package_submodule_name = f"tools.{package_submodule_name}"
+        import geneweaver.tools
 
-    assert hasattr(geneweaver, package_submodule_name), ERROR_MESSAGE
-    assert getattr(geneweaver, package_submodule_name) is not None, ERROR_MESSAGE
+        assert hasattr(geneweaver.tools, package_submodule_name), ERROR_MESSAGE
+        assert (
+            getattr(geneweaver.tools, package_submodule_name) is not None
+        ), ERROR_MESSAGE
+    else:
+        import geneweaver
+
+        assert hasattr(geneweaver, package_submodule_name), ERROR_MESSAGE
+        assert getattr(geneweaver, package_submodule_name) is not None, ERROR_MESSAGE

--- a/src/geneweaver/testing/package/generic/pyproject.py
+++ b/src/geneweaver/testing/package/generic/pyproject.py
@@ -301,4 +301,4 @@ def test_ruff_per_files_ignores(
         for ignore in per_files_ignores["tests/*"]:
             assert ignore in ("ANN201", "ANN001"), PER_FILES_IGNORES_MSG
     else:
-        warnings.warn(IGNORING_ALLOWED_WARN)
+        warnings.warn(IGNORING_ALLOWED_WARN)  # noqa: B028

--- a/src/geneweaver/testing/package/structure.py
+++ b/src/geneweaver/testing/package/structure.py
@@ -25,10 +25,14 @@ def test_geneweaver_dir_is_namespace_package(project_root: pathlib.Path) -> None
 
 
 def test_has_package_directory(
-    project_root: pathlib.Path, package_submodule_name: str
+    project_root: pathlib.Path, package_submodule_name: str, is_tool_package: bool
 ) -> None:
     """Test that the package directory exists."""
-    assert (project_root / "src" / "geneweaver" / package_submodule_name).is_dir(), (
+    root_path = project_root / "src" / "geneweaver"
+    if is_tool_package:
+        root_path = root_path / "tools"
+
+    assert (root_path / package_submodule_name).is_dir(), (
         f'"{package_submodule_name}" package directory '
         f'expected in "geneweaver" namespace'
     )


### PR DESCRIPTION
Fix for package names with dash, style fix, ruff config change, pyproject patch version

This change came about from usage in the geneweaver-boolean-algebra tool refactor. 