### PR TITLE
Adding special exception for geneweaver api controller

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-testing"
-version = "0.0.2"
+version = "0.0.3"
 description = "A library to standardize testing of GeneWeaver pacakges."
 authors = ["Alexander Berger <alexander.berger@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/testing/package/generic/pyproject.py
+++ b/src/geneweaver/testing/package/generic/pyproject.py
@@ -307,10 +307,12 @@ def _check_src_per_file_ignore(per_files_ignores: dict) -> None:
 
 
 def _check_controller_per_file_ignore(per_files_ignores: dict) -> None:
-    assert "src/geneweaver/api/controllers/*" in per_files_ignores, PER_FILES_IGNORES_MSG
-    assert len(per_files_ignores["src/geneweaver/api/controllers/*"]) == 1, (
-        PER_FILES_IGNORES_MSG
-    )
+    assert (
+        "src/geneweaver/api/controllers/*" in per_files_ignores
+    ), PER_FILES_IGNORES_MSG
+    assert (
+        len(per_files_ignores["src/geneweaver/api/controllers/*"]) == 1
+    ), PER_FILES_IGNORES_MSG
     assert (
         per_files_ignores["src/geneweaver/api/controllers/*"][0] == "B008"
     ), PER_FILES_IGNORES_MSG

--- a/src/geneweaver/testing/package/generic/pyproject.py
+++ b/src/geneweaver/testing/package/generic/pyproject.py
@@ -175,7 +175,7 @@ def test_poetry_build_system_definition(
     assert "build-system" in pyproject_toml_contents, error_msg
     assert "requires" in pyproject_toml_contents["build-system"], error_msg
     assert (
-        "poetry-core" == pyproject_toml_contents["build-system"]["requires"]
+        "poetry-core" in pyproject_toml_contents["build-system"]["requires"]
     ), error_msg
     assert "build-backend" in pyproject_toml_contents["build-system"], error_msg
     assert (
@@ -323,7 +323,9 @@ def test_ruff_per_files_ignores(
 ) -> None:
     """Ensure that the ruff configuration only ignores allowed errors."""
     # You can optionally ignore argument and return type annotations in tests.
-    per_files_ignores = pyproject_toml_contents["tool"]["ruff"].get("per-file-ignores")
+    tool_ruff = pyproject_toml_contents.get("tool", {}).get("ruff", None)
+    assert tool_ruff is not None, RUFF_ERROR_MSG
+    per_files_ignores = tool_ruff.get("per-file-ignores")
     if per_files_ignores:
         assert len(per_files_ignores) in (1, 2, 3), PER_FILES_IGNORES_MSG
         if len(per_files_ignores) == 3:

--- a/src/geneweaver/testing/package/generic/pyproject.py
+++ b/src/geneweaver/testing/package/generic/pyproject.py
@@ -241,7 +241,10 @@ PER_FILES_IGNORES_MSG = (
     '"tests/*" = ["ANN201"]\n'
     '"src/*" = ["ANN101"]\n\n'
     "You can optionally ignore argument type annotations (`ANN001`) in `tests/*`, but "
-    "it is not recommended.\n"
+    "it is not recommended.\n\n"
+    "NOTE: The geneweaver-api package has an additional per-file-ignore for "
+    "controllers:\n\n"
+    '"src/geneweaver/api/controllers/*" = ["B008"]\n\n'
 )
 
 IGNORING_ALLOWED_WARN = (
@@ -303,6 +306,16 @@ def _check_src_per_file_ignore(per_files_ignores: dict) -> None:
     assert per_files_ignores["src/*"][0] == "ANN101", PER_FILES_IGNORES_MSG
 
 
+def _check_controller_per_file_ignore(per_files_ignores: dict) -> None:
+    assert "src/geneweaver/api/controllers/*" in per_files_ignores, PER_FILES_IGNORES_MSG
+    assert len(per_files_ignores["src/geneweaver/api/controllers/*"]) == 1, (
+        PER_FILES_IGNORES_MSG
+    )
+    assert (
+        per_files_ignores["src/geneweaver/api/controllers/*"][0] == "B008"
+    ), PER_FILES_IGNORES_MSG
+
+
 def test_ruff_per_files_ignores(
     pyproject_toml_contents: Optional[dict],
 ) -> None:
@@ -310,8 +323,12 @@ def test_ruff_per_files_ignores(
     # You can optionally ignore argument and return type annotations in tests.
     per_files_ignores = pyproject_toml_contents["tool"]["ruff"].get("per-file-ignores")
     if per_files_ignores:
-        assert len(per_files_ignores) in (1, 2), PER_FILES_IGNORES_MSG
-        if len(per_files_ignores) == 2:
+        assert len(per_files_ignores) in (1, 2, 3), PER_FILES_IGNORES_MSG
+        if len(per_files_ignores) == 3:
+            _check_tests_per_file_ignore(per_files_ignores)
+            _check_src_per_file_ignore(per_files_ignores)
+            _check_controller_per_file_ignore(per_files_ignores)
+        elif len(per_files_ignores) == 2:
             _check_tests_per_file_ignore(per_files_ignores)
             _check_src_per_file_ignore(per_files_ignores)
         elif len(per_files_ignores) == 1 and "src/*" in per_files_ignores:

--- a/tests/package/__init__.py
+++ b/tests/package/__init__.py
@@ -1,0 +1,1 @@
+"""Test the geneweaver.testing.pacakge module."""

--- a/tests/package/generic/__init__.py
+++ b/tests/package/generic/__init__.py
@@ -1,0 +1,1 @@
+"""Test the geneweaver.testing.package.generic module."""

--- a/tests/package/generic/test_pyproject.py
+++ b/tests/package/generic/test_pyproject.py
@@ -1,0 +1,79 @@
+"""Test the geneweaver.testing.package.generic.pyproject module."""
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+from geneweaver.testing.package.generic.pyproject import (
+    _check_controller_per_file_ignore,
+)
+from geneweaver.testing.package.generic.pyproject import (
+    test_poetry_build_system_definition as t_poetry_build_system_definition,
+)
+from geneweaver.testing.package.generic.pyproject import (
+    test_ruff_per_files_ignores as t_ruff_per_files_ignores,
+)
+
+
+def test_test_poetry_build_system_definition():
+    """Test with a valid pyproject.toml content."""
+    valid_pyproject_content = {
+        "build-system": {
+            "requires": ["poetry-core"],
+            "build-backend": "poetry.masonry.api",
+        }
+    }
+    t_poetry_build_system_definition(valid_pyproject_content)
+
+
+def test_controller_per_file_ignore():
+    """Test the _check_controller_per_file_ignore function."""
+    valid_per_files_ignore = {
+        "tests/*": ["test_*.py", "tests/*"],
+        "src/geneweaver/api/controllers/*": ["B008"],
+        "src/*": ["ANN101", "ANN102", "ANN103", "ANN204", "ANN205", "ANN206"],
+    }
+    _check_controller_per_file_ignore(valid_per_files_ignore)
+
+
+PER_FILES_IGNORES_MSG = "custom error message for per-files-ignores"
+IGNORING_ALLOWED_WARN = "custom warning message for ignoring allowed"
+
+
+@pytest.mark.parametrize(
+    "pyproject_toml_contents",
+    [
+        {"tool": {"ruff": {"per-file-ignores": ["src/*"]}}},
+        {"tool": {"ruff": {"per-file-ignores": ["tests/*"]}}},
+        {"tool": {"ruff": {"per-file-ignores": ["src/*", "tests/*"]}}},
+        {"tool": {"ruff": {"per-file-ignores": ["src/*", "tests/*", "controllers/*"]}}},
+    ],
+)
+def test_test_ruff_per_files_ignores(
+    pyproject_toml_contents: Optional[dict],
+):
+    """Test different scenarios of pyproject.toml contents for ruff configuration."""
+    with patch(
+        "geneweaver.testing.package.generic.pyproject._check_tests_per_file_ignore"
+    ) as mock_test_ignore, patch(
+        "geneweaver.testing.package.generic.pyproject._check_src_per_file_ignore"
+    ) as mock_src_ignore, patch(
+        "geneweaver.testing.package.generic.pyproject._check_controller_per_file_ignore"
+    ) as mock_controller_ignore:
+        # Call the function under test
+        t_ruff_per_files_ignores(pyproject_toml_contents)
+
+        # Assert that the mocks were called as expected
+        if (
+            pyproject_toml_contents
+            and "per-file-ignores"
+            in pyproject_toml_contents.get("tool", {}).get("ruff", {})
+        ):
+            per_files_ignores = pyproject_toml_contents["tool"]["ruff"][
+                "per-file-ignores"
+            ]
+            if "tests/*" in per_files_ignores:
+                mock_test_ignore.assert_called_with(per_files_ignores)
+            if "src/*" in per_files_ignores:
+                mock_src_ignore.assert_called_with(per_files_ignores)
+            if len(per_files_ignores) == 3:
+                mock_controller_ignore.assert_called_with(per_files_ignores)


### PR DESCRIPTION
This PR change adds a special exception to the acceptable Ruff configuration to allow the geneweaver-api package to use the d[ependency injection style of FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/#declare-the-dependency-in-the-dependant) without ignoring [B008](https://docs.astral.sh/ruff/rules/function-call-in-default-argument/) for every controller file.